### PR TITLE
Allow checked mailer recipients to also include bcc and cc emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ You can also test that someone has not received an email.
 expect(some_user).not_to have_received_email
 ```
 
+Emails sent to users using `bcc` or `cc` can be tested using:
+
+```ruby
+expect("cc@email.com").to have_received_cc_email(body: "Wonderful email body")
+expect("bcc@email.com").to have_received_bcc_email(body: "Wonderful email body")
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/contently/action_mailer_matchers/fork )

--- a/lib/action_mailer_matchers.rb
+++ b/lib/action_mailer_matchers.rb
@@ -5,36 +5,52 @@ module ActionMailerMatchers
 
   matcher :have_received_email do |email_or_user|
     match do |email_or_user|
-      expected_attrs = expected.present? ? expected : {}
-      email = email_or_user.try(:email) || email_or_user
-      email_subject = expected_attrs[:subject]
-      body = expected_attrs[:body]
-
-      matching_email = matching_mail_for(email, body, email_subject)
-
-      expect(matching_email.present?).to eql(true)
+      received_email?(email_or_user, expected)
     end
+  end
 
-    def matching_mail_for(email, body, email_subject)
-      deliveries.detect do |mail|
-        has_expected_email = mail.to.include?(email)
-        has_expected_body = body ? body_for(mail).include?(body) : true
-        has_expected_subject = email_subject ? mail.subject.include?(email_subject) : true
-
-        has_expected_email && has_expected_body && has_expected_subject
-      end
+  matcher :have_received_cc_email do |email_or_user|
+    match do |email_or_user|
+      received_email?(email_or_user, expected, :cc)
     end
+  end
 
-    def body_for(mail)
-      if mail.try(:parts).present?
-        mail.try(:parts).try(:first).try(:body).try(:raw_source)
-      else
-        mail.try(:body).try(:raw_source)
-      end
+  matcher :have_received_bcc_email do |email_or_user|
+    match do |email_or_user|
+      received_email?(email_or_user, expected, :bcc)
     end
+  end
 
-    def deliveries
-      ActionMailer::Base.deliveries
+  def received_email?(email_or_user, expected, email_method = :to)
+    expected_attrs = expected.present? ? expected : {}
+    email = email_or_user.try(:email) || email_or_user
+    email_subject = expected_attrs[:subject]
+    body = expected_attrs[:body]
+
+    matching_email = matching_mail_for(email, body, email_subject, email_method)
+
+    expect(matching_email.present?).to eql(true)
+  end
+
+  def matching_mail_for(email, body, email_subject, email_method)
+    deliveries.detect do |mail|
+      has_expected_email = mail.send(email_method).include?(email)
+      has_expected_body = body ? body_for(mail).include?(body) : true
+      has_expected_subject = email_subject ? mail.subject.include?(email_subject) : true
+
+      has_expected_email && has_expected_body && has_expected_subject
     end
+  end
+
+  def body_for(mail)
+    if mail.try(:parts).present?
+      mail.try(:parts).try(:first).try(:body).try(:raw_source)
+    else
+      mail.try(:body).try(:raw_source)
+    end
+  end
+
+  def deliveries
+    ActionMailer::Base.deliveries
   end
 end


### PR DESCRIPTION
We've run into a few instances where we'd like to check the bcc and cc emails

- Change checked recipients from only the mailer's `.to` recipient, to also check other recipients (`.bcc`, `.cc`)
- Add new helper methods `have_received_bcc_email` and `have_received_cc_email`